### PR TITLE
Resolve local ajax cross origin issues in firefox by removing json load requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,15 @@ The Raphael example was built using a similar structure pattern to how p5 exampl
 
   * Processing - p5.js - http://p5js.org/
   * Raphael - raphael.js - http://raphaeljs.com/
-  
-  
+
+#Running Locally
+### Without Webserver
+Only Firefox is supported
+- Open p5.html and/or raphael.html in your browser to see samples
+
+### With Webserver
+Works cross browser
+###### Python example
+- Navigate via Command Line to the project root
+- run `python -m SimpleHTTPServer`
+- Open `localhost:8000/p5.html` and/or `localhost:8000/raphael.html` in your browser to see samples

--- a/data/states.js
+++ b/data/states.js
@@ -1,4 +1,5 @@
-{ "States": [
+var flags = [];
+var states = [
 	{ "name": "Alabama", "imgname": "AL", "date": "1819", "capital": "Montgomery" },
 	{ "name": "Alaska", "imgname": "AK", "date": "1959", "capital": "Juneau" },
 	{ "name": "Arizona", "imgname": "AZ", "date": "1912", "capital": "Phoenix" },
@@ -49,5 +50,4 @@
 	{ "name": "West Virginia", "imgname": "WV", "date": "1863", "capital": "Charleston" },
 	{ "name": "Wisconsin", "imgname": "WI", "date": "1848", "capital": "Madison" },
 	{ "name": "Wyoming", "imgname": "WY", "date": "1890", "capital": "Cheyenne" }
-	]
-}
+	];

--- a/js/main-p.js
+++ b/js/main-p.js
@@ -1,22 +1,13 @@
 // Graphic experiment using p5.js
 
-// Globals
-var states, flags = [];
-
-// loadJSON callback
-function statesCallback(response) {
-    states = response.States;
-
-    // load flag images
-    for (var i = states.length - 1; i >= 0; i--) {
-        flags[i] = loadImage("images/state_flags/" + states[i].imgname + ".png");
-    };
+function loadFlags(){
+  for (var i = states.length - 1; i >= 0; i--) {
+    flags[i] = loadImage("images/state_flags/" + states[i].imgname + ".png");
+  }
 }
 
 function setup() {
-    var url = 'data/states.json';
-    loadJSON(url, statesCallback);
-
+    loadFlags();
     // Create the canvas
     createCanvas(windowWidth, 3000);
     background(0);

--- a/js/main-r.js
+++ b/js/main-r.js
@@ -1,7 +1,6 @@
 // Graphic experiment using Raphael.js
 
 // Globals
-var states, flags = [];
 var ww = window.innerWidth;
 var wh = window.innerHeight * 3;
 
@@ -10,24 +9,19 @@ var r = Raphael(0, 0, ww, wh);
 
 setup();
 
-// loadJSON callback
-function statesCallback(response) {
-    states = response.States;
-
+function loadFlags() {
     // Loads flag images
     for (var i = states.length - 1; i >= 0; i--) {
         flags[i] = new Image();
         flags[i].src = 'images/state_flags/' + states[i].imgname + '.png';
         flags[i].style.display = "none";
-    };
+    }
 
     flags[0].onload = draw;
 }
 
 function setup(){
-  var url = 'data/states.json';
-  loadJSON ( url, statesCallback );
-
+  loadFlags();
   // Draw red border
   r.rect(5, 5, ww - 10, wh - 10, 10).attr({ stroke: "#600" });
 

--- a/p5.html
+++ b/p5.html
@@ -8,6 +8,7 @@
         <link rel="stylesheet" href="css/style.css">
     </head>
     <body>
+        <script src="data/states.js"></script>
         <script src="js/p5/p5.js"></script>
         <script src="js/main-p.js"></script>
     </body>

--- a/raphael.html
+++ b/raphael.html
@@ -8,8 +8,8 @@
         <link rel="stylesheet" href="css/style.css">
     </head>
     <body>
+        <script src="data/states.js"></script>
         <script src="js/raphael/raphael-min.js"></script>
-        <script src="js/loadJSON.js"></script>
         <script src="js/main-r.js"></script>
     </body>
 </html>


### PR DESCRIPTION
#### PROBLEM

Cross origin is a pain, especially when using the `file://` protocol. I venture that you have modified the security restrictions in your version of Firefox when working with loading local JSON because it binds up in a vanilla firefox install from my testing. That said we can solve this cross origin issue in Firefox but not Chrome because Chrome has a bug currently. All this can be run under a webserver like `python -m SimpleHTTPServer` as well for the non firefox peeps.
#### SOLUTION

Makes states data a script so it doesn't need to be ajaxed
Removed ajax step from main-p and main-r and replaced them with just
the image loader portions. Renamed to loadFlags

There is a cross origin image loading issue in chrome but this works in
firefox without security modifications
